### PR TITLE
fix: add placeholder for items with no image

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -48,7 +48,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || "../placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -37,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
Fixed it!
![image](https://user-images.githubusercontent.com/57040351/209408175-cd10a327-6cac-4f05-9c8f-2ec536c4d443.png)
![image](https://user-images.githubusercontent.com/57040351/209408183-004d46d7-cd10-48ca-9d81-511d5a999b7d.png)
